### PR TITLE
Fix startAt, endAt, equalTo optional 2nd params on Android

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackDatabase.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackDatabase.java
@@ -641,7 +641,7 @@ class FirestackDatabaseModule extends ReactContextBaseJavaModule {
         query = query.limitToFirst(limit);
       } else if (methStr.contains("equalTo")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.equalTo(value);
         } else {
@@ -649,7 +649,7 @@ class FirestackDatabaseModule extends ReactContextBaseJavaModule {
         }
       } else if (methStr.contains("endAt")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.endAt(value);
         } else {
@@ -657,7 +657,7 @@ class FirestackDatabaseModule extends ReactContextBaseJavaModule {
         }
       } else if (methStr.contains("startAt")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.startAt(value);
         } else {


### PR DESCRIPTION
Fixes
```
E/unknown:React: Exception in native call
                 java.lang.ArrayIndexOutOfBoundsException: length=2; index=2
                     at io.fullstack.firestack.FirestackDBReference.getDatabaseQueryAtPathAndModifiers(FirestackDatabase.java:235)
                     at io.fullstack.firestack.FirestackDBReference.addChildEventListener(FirestackDatabase.java:90)
                     at io.fullstack.firestack.FirestackDatabaseModule.on(FirestackDatabase.java:379)
                     at java.lang.reflect.Method.invoke(Native Method)
                     at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:319)
                     at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
                     at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
                     at android.os.Handler.handleCallback(Handler.java:751)
                     at android.os.Handler.dispatchMessage(Handler.java:95)
                     at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
                     at android.os.Looper.loop(Looper.java:154)
                     at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:196)
                     at java.lang.Thread.run(Thread.java:761)
```