### PR TITLE
Fix startAt, endAt, equalTo optional 2nd param for Android getDatabaseQueryAtPathAndModifiers

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackDatabase.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackDatabase.java
@@ -247,7 +247,7 @@ class FirestackDBReference {
         query = query.limitToFirst(limit);
       } else if (methStr.contains("equalTo")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.equalTo(value);
         } else {
@@ -255,7 +255,7 @@ class FirestackDBReference {
         }
       } else if (methStr.contains("endAt")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.endAt(value);
         } else {
@@ -263,7 +263,7 @@ class FirestackDBReference {
         }
       } else if (methStr.contains("startAt")) {
         String value = strArr[1];
-        String key = strArr[2];
+        String key = strArr.length >= 3 ? strArr[2] : null;
         if (key == null) {
           query = query.startAt(value);
         } else {


### PR DESCRIPTION
Same fix as last time, just in the other method