### PR TITLE
Allow removal of specific callbacks from query listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,23 +592,33 @@ storageRef.downloadUrl()
 
 ### Realtime Database
 
-#### database attribute
-
 The native Firebase JavaScript library provides a featureful realtime database that works out of the box. Firestack provides an attribute to interact with the database without needing to configure the JS library.
-
-```javascript
-firestack.database
-      .ref(LIST_KEY)
-      .on('value', snapshot => {
-        if (snapshot.val()) {
-          console.log('The list was updated');
-        }
-      });
-```
 
 #### DatabaseRef
 
-Firestack attempts to provide the same API as the JS Firebase library for both Android and iOS platforms.
+Firestack attempts to provide the same API as the JS Firebase library for both Android and iOS platforms. [Check out the firebase guide](https://firebase.google.com/docs/database/web/read-and-write) for more information on how to use the JS library.
+
+#### Example
+
+```javascript
+
+function handleValueChange(snapshot) {
+  if (snapshot.val()) {
+    console.log('The list was updated');
+  }
+}
+
+const LIST_KEY = 'path/to/data';
+firestack.database.ref(LIST_KEY).on('value', handleValueChange);
+
+// Calling `.off` with a reference to the callback function will only remove that specific listener.
+// This is useful if multiple components are listening and unlistening to the same ref path.
+firestack.database.ref(LIST_KEY).off('value', handleValueChange);
+
+// Calling `.off` without passing the callback function will remove *all* 'value' listeners for that ref
+firestack.database.ref(LIST_KEY).off('value');
+
+```
 
 // TODO: Finish documenting
 

--- a/lib/modules/database.js
+++ b/lib/modules/database.js
@@ -211,10 +211,14 @@ class DatabaseRef extends ReferenceBase {
       })
   }
 
-  off(evt='') {
+  off(evt='', origCB) {
     const path = this.dbPath();
-    return this.db.off(path, evt)
+    return this.db.off(path, evt, origCB)
       .then(({callback, subscriptions}) => {
+        if (dbSubscriptions[path][evt].length > 0) {
+          return subscriptions;
+        }
+
         return promisify('off', FirestackDatabase)(path, evt)
           .then(() => {
             // subscriptions.forEach(sub => sub.remove());
@@ -432,15 +436,20 @@ export class Database extends Base {
     return Promise.resolve({callback, subscriptions});
   }
 
-  off(path, evt) {
+  off(path, evt, origCB) {
     const key = this._pathKey(path);
     // Remove subscription
     if (dbSubscriptions[key]) {
       if (!evt || evt === "") {
         dbSubscriptions[key] = {};
       } else if (dbSubscriptions[key][evt]) {
-        delete dbSubscriptions[key][evt];
+        if (origCB) {
+          dbSubscriptions[key][evt].splice(dbSubscriptions[key][evt].indexOf(origCB), 1);
+        } else {
+          delete dbSubscriptions[key][evt];
+        }
       }
+
       if (Object.keys(dbSubscriptions[key]).length <= 0) {
         // there are no more subscriptions
         // so we can unwatch


### PR DESCRIPTION
This addresses an issue where calling `.off` would remove all of the listeners for a particular query path. 