### PR TITLE
Fixed provider google on Android (was missing)

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
@@ -138,6 +138,8 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
     public void signInWithProvider(final String provider, final String authToken, final String authSecret, final Callback callback) {
       if (provider.equals("facebook")) {
            this.facebookLogin(authToken,callback);
+      } else if (provider.equals("google")) {
+           this.googleLogin(authToken,callback);
       } else
       // TODO
       FirestackUtils.todoNote(TAG, "signInWithProvider", callback);


### PR DESCRIPTION
I was trying to use **react-native-google-signin** but I was receiving **error: unimplemented** until I found the problem.