### PR TITLE
Stop passing getApplicationContext() in to the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new FirestackPackage(getApplicationContext())
+            new FirestackPackage()
       );
     }
   };

--- a/android/src/main/java/io/fullstack/firestack/FirestackPackage.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackPackage.java
@@ -15,8 +15,7 @@ import java.util.List;
 public class FirestackPackage implements ReactPackage {
     private Context mContext;
 
-    public FirestackPackage(Context ctx) {
-        mContext = ctx;
+    public FirestackPackage() {
     }
     /**
      * @param reactContext react application context that can be used to create modules
@@ -26,7 +25,7 @@ public class FirestackPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        modules.add(new FirestackModule(reactContext, mContext));
+        modules.add(new FirestackModule(reactContext, reactContext.getBaseContext()));
         modules.add(new FirestackAuthModule(reactContext));
         modules.add(new FirestackDatabaseModule(reactContext));
         modules.add(new FirestackAnalyticsModule(reactContext));

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "project": "ios/Firestack.xcodeproj"
     },
     "android": {
-      "packageInstance": "new FirestackPackage(getApplicationContext())"
+      "packageInstance": "new FirestackPackage()"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
It's not necessary, and can be derived from the ReactApplicationContext object.

This was preventing me from compiling android on my RN 0.33 build, so I thought I'd fix it up (compiles, and am able to use Database calls properly now). Not entirely sure why I don't see any issues or pull requests about this, so I suspect I'm missing something obvious here...