### PR TITLE
Prevent race condition with listenForAuth (iOS)

### DIFF
--- a/ios/Firestack/FirestackAuth.h
+++ b/ios/Firestack/FirestackAuth.h
@@ -15,6 +15,7 @@
 
 @interface FirestackAuth : RCTEventEmitter <RCTBridgeModule> {
     FIRAuthStateDidChangeListenerHandle authListenerHandle;
+    Boolean listening;
 }
 
 @end

--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -130,6 +130,7 @@ RCT_EXPORT_METHOD(signOut:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(listenForAuth)
 {
+    self->listening = true;
     self->authListenerHandle =
     [[FIRAuth auth] addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth,
                                                     FIRUser *_Nullable user) {
@@ -174,13 +175,9 @@ RCT_EXPORT_METHOD(unlistenForAuth:(RCTResponseSenderBlock)callback)
 {
     if (self->authListenerHandle != nil) {
         [[FIRAuth auth] removeAuthStateDidChangeListener:self->authListenerHandle];
+        self->listening = false;
         callback(@[[NSNull null]]);
     }
-}
-
-// Helper
-- (Boolean) listeningForAuth {
-  return (self->authListenerHandle != nil);
 }
 
 RCT_EXPORT_METHOD(getCurrentUser:(RCTResponseSenderBlock)callback)
@@ -496,7 +493,7 @@ RCT_EXPORT_METHOD(updateUserProfile:(NSDictionary *)userProps
                props:(NSDictionary *)props
 {
     @try {
-      if ([self listeningForAuth]) {
+      if (self->listening) {
         [self sendEventWithName:title
                            body:props];
       }


### PR DESCRIPTION
I have found that it is possible for the first auth event to be fired before the listeningForAuth check returns true.  This results in the event not being transmitted to the front end, so is effectively lost.

This is a simple PR to set a boolean flag instead of relying on the reference to indicate whether the class is listeningForAuth;