### PR TITLE
Fix for exceptions thrown by Firebase

### DIFF
--- a/ios/Firestack/Firestack.m
+++ b/ios/Firestack/Firestack.m
@@ -239,7 +239,9 @@ RCT_EXPORT_METHOD(configureWithOptions:(NSDictionary *) opts
             
             // if (!self.configured) {
             
-            [FIRApp configureWithOptions:finalOptions];
+            if ([FIRApp defaultApp] == NULL) {
+                [FIRApp configureWithOptions:finalOptions];
+            }            
             [Firestack initializeFirestack:self];
             callback(@[[NSNull null], props]);
         }

--- a/ios/Firestack/FirestackDatabase.m
+++ b/ios/Firestack/FirestackDatabase.m
@@ -240,7 +240,11 @@ RCT_EXPORT_MODULE(FirestackDatabase);
 RCT_EXPORT_METHOD(enablePersistence:(BOOL) enable
   callback:(RCTResponseSenderBlock) callback)
 {
-  [FIRDatabase database].persistenceEnabled = enable;
+    
+  BOOL isEnabled = [FIRDatabase database].persistenceEnabled;
+  if ( isEnabled != enable) {
+    [FIRDatabase database].persistenceEnabled = enable;
+  }
   callback(@[[NSNull null], @{
     @"result": @"success"
   }]);


### PR DESCRIPTION
When the app is reloaded two exceptions occur.
1. Default app has already been configured.
2. calls to setPersistenceEnabled must be made before any other usage of FIRDatabase.

This PR fixes them.