### PR TITLE
Remove auth methods from instance root & update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,14 @@ All methods return a promise.
 
 Firestack handles authentication for us out of the box, both with email/password-based authentication and through oauth providers (with a separate library to handle oauth providers).
 
+> Android requires the Google Play services to installed for authentication to function.
+
 #### listenForAuth()
 
 Firebase gives us a reactive method for listening for authentication. That is we can set up a listener to call a method when the user logs in and out. To set up the listener, call the `listenForAuth()` method:
 
 ```javascript
-firestack.listenForAuth(function(evt) {
+firestack.auth.listenForAuth(function(evt) {
   // evt is the authentication event
   // it contains an `error` key for carrying the
   // error message in case of an error
@@ -306,7 +308,7 @@ firestack.listenForAuth(function(evt) {
 We can remove this listener by calling the `unlistenForAuth()` method. This is important to release resources from our app when we don't need to hold on to the listener any longer.
 
 ```javascript
-firestack.unlistenForAuth()
+firestack.auth.unlistenForAuth()
 ```
 
 #### createUserWithEmail()
@@ -314,7 +316,7 @@ firestack.unlistenForAuth()
 We can create a user by calling the `createUserWithEmail()` function. The `createUserWithEmail()` accepts two parameters, an email and a password.
 
 ```javascript
-firestack.createUserWithEmail('ari@fullstack.io', '123456')
+firestack.auth.createUserWithEmail('ari@fullstack.io', '123456')
   .then((user) => {
     console.log('user created', user)
   })
@@ -342,7 +344,7 @@ firestack.auth.signInWithEmail('ari@fullstack.io', '123456')
 To sign a user using a self-signed custom token, use the `signInWithCustomToken()` function. It accepts one parameter, the custom token:
 
 ```javascript
-firestack.signInWithCustomToken(TOKEN)
+firestack.auth.signInWithCustomToken(TOKEN)
   .then((user) => {
     console.log('User successfully logged in', user)
   })
@@ -397,7 +399,7 @@ When the auth token has expired, we can ask firebase to reauthenticate with the 
 We can update the current user's email by using the command: `updateUserEmail()`. It accepts a single argument: the user's new email:
 
 ```javascript
-firestack.updateUserEmail('ari+rocks@fullstack.io')
+firestack.auth.updateUserEmail('ari+rocks@fullstack.io')
   .then((res) => console.log('Updated user email'))
   .catch(err => console.error('There was an error updating user email'))
 ```
@@ -407,7 +409,7 @@ firestack.updateUserEmail('ari+rocks@fullstack.io')
 We can update the current user's password using the `updateUserPassword()` method. It accepts a single parameter: the new password for the current user
 
 ```javascript
-firestack.updateUserPassword('somethingReallyS3cr3t733t')
+firestack.auth.updateUserPassword('somethingReallyS3cr3t733t')
   .then(res => console.log('Updated user password'))
   .catch(err => console.error('There was an error updating your password'))
 ```
@@ -417,7 +419,7 @@ firestack.updateUserPassword('somethingReallyS3cr3t733t')
 To send a password reset for a user based upon their email, we can call the `sendPasswordResetWithEmail()` method. It accepts a single parameter: the email of the user to send a reset email.
 
 ```javascript
-firestack.sendPasswordResetWithEmail('ari+rocks@fullstack.io')
+firestack.auth.sendPasswordResetWithEmail('ari+rocks@fullstack.io')
   .then(res => console.log('Check your inbox for further instructions'))
   .catch(err => console.error('There was an error :('))
 ```
@@ -431,7 +433,7 @@ It accepts a single parameter:
 * object which contains updated key/values for the user's profile. Possible keys are listed [here](https://firebase.google.com/docs/auth/ios/manage-users#update_a_users_profile).
 
 ```javascript
-firestack.updateUserProfile({
+firestack.auth.updateUserProfile({
   displayName: 'Ari Lerner'
 })
   .then(res => console.log('Your profile has been updated'))
@@ -443,7 +445,7 @@ firestack.updateUserProfile({
 It's possible to delete a user completely from your account on Firebase. Calling the `deleteUser()` method will take care of this for you.
 
 ```javascript
-firestack.deleteUser()
+firestack.auth.deleteUser()
 .then(res => console.log('Sad to see you go'))
 .catch(err => console.error('There was an error - Now you are trapped!'))
 ```
@@ -453,7 +455,7 @@ firestack.deleteUser()
 If you want user's token, use `getToken()` method.
 
 ```javascript
-firestack.getToken()
+firestack.auth.getToken()
 .then(res => console.log(res.token))
 .catch(err => console.error('error'))
 ```
@@ -463,7 +465,7 @@ firestack.getToken()
 To sign the current user out, use the `signOut()` method. It accepts no parameters
 
 ```javascript
-firestack.signOut()
+firestack.auth.signOut()
 .then(res => console.log('You have been signed out'))
 .catch(err => console.error('Uh oh... something weird happened'))
 ```
@@ -473,7 +475,7 @@ firestack.signOut()
 Although you _can_ get the current user using the `getCurrentUser()` method, it's better to use this from within the callback function provided by `listenForAuth()`. However, if you need to get the current user, call the `getCurrentUser()` method:
 
 ```javascript
-firestack.getCurrentUser()
+firestack.auth.getCurrentUser()
 .then(user => console.log('The currently logged in user', user))
 .catch(err => console.error('An error occurred'))
 ```

--- a/lib/modules/authentication.js
+++ b/lib/modules/authentication.js
@@ -9,18 +9,6 @@ import { Base } from './base'
 export class Authentication extends Base {
   constructor(firestack, options={}) {
     super(firestack, options);
-
-    this._addToFirestackInstance(
-      'listenForAuth', 'unlistenForAuth',
-      'createUserWithEmail', 'signInWithEmail',
-      'signInAnonymously',
-      'signInWithProvider', 'signInWithCustomToken',
-      'reauthenticateWithCredentialForProvider', 
-      'updateUserEmail', 'updatePassword',
-      'updateUserProfile', 'sendPasswordResetWithEmail',
-      'deleteUser', 'getToken', 
-      'signOut', 'getCurrentUser'
-    )
   }
 
   // Auth


### PR DESCRIPTION
All the auth methods are on both the auth namespace and instance root. This PR moves them to the auth namespace only.