### PR TITLE
Change getBinder to get bundle

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackAnalytics.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackAnalytics.java
@@ -213,11 +213,11 @@ class FirestackAnalyticsModule extends ReactContextBaseJavaModule {
       String val = (String) map.get("flight_number");
       bundle.putString(FirebaseAnalytics.Param.FLIGHT_NUMBER, val);
     }
-    
+
     Iterator<Map.Entry<String, Object>> entries = map.entrySet().iterator();
     while (entries.hasNext()) {
       Map.Entry<String, Object> entry = entries.next();
-      if (bundle.getBinder(entry.getKey()) == null) {
+      if (bundle.getBundle(entry.getKey()) == null) {
         bundle.putString(entry.getKey(), entry.getValue().toString());
       }
     }


### PR DESCRIPTION
getBinder is introduced in API 18, any app with a minSdk below 18 will
crash because getBinder is not there, so i changed it to getBundle which
gives the same result according to the docs.