### PR TITLE
Fix listeners with modifiers

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackUtils.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackUtils.java
@@ -50,7 +50,8 @@ public class FirestackUtils {
 
   // snapshot
   public static WritableMap dataSnapshotToMap(String name, 
-    String path, 
+    String path,
+    String modifiersString,
     DataSnapshot dataSnapshot) {
       WritableMap data = Arguments.createMap();
 
@@ -98,6 +99,7 @@ public class FirestackUtils {
       WritableMap eventMap = Arguments.createMap();
       eventMap.putString("eventName", name);
       eventMap.putMap("snapshot", data);
+      eventMap.putString("modifiersString", modifiersString);
       eventMap.putString("path", path);
       return eventMap;
   }

--- a/lib/modules/database.js
+++ b/lib/modules/database.js
@@ -5,11 +5,10 @@ import {NativeModules, NativeEventEmitter} from 'react-native';
 const FirestackDatabase = NativeModules.FirestackDatabase;
 const FirestackDatabaseEvt = new NativeEventEmitter(FirestackDatabase);
 
-import promisify from '../utils/promisify'
-import { Base, ReferenceBase } from './base'
+import promisify from '../utils/promisify';
+import { Base, ReferenceBase } from './base';
 
-// subscriptionsMap === { path: { modifier: { eventType: [Subscriptions] } } }
-let dbSubscriptions = {};
+let dbSubscriptions = {}; // { path: { modifier: { eventType: [Subscriptions] } } }
 
 class DataSnapshot {
   static key:String;
@@ -36,12 +35,12 @@ class DataSnapshot {
 
   forEach(fn) {
     (this.childKeys || [])
-      .forEach(key => fn(this.value[key]))
+      .forEach(key => fn(this.value[key]));
   }
 
   map(fn) {
     let arr = [];
-    this.forEach(item => arr.push(fn(item)))
+    this.forEach(item => arr.push(fn(item)));
     return arr;
   }
 
@@ -57,9 +56,9 @@ class DatabaseOnDisconnect {
 
   setValue(val) {
     const path = this.ref.dbPath();
-    if (typeof val == 'string') {
+    if (typeof val === 'string') {
       return promisify('onDisconnectSetString', FirestackDatabase)(path, val);
-    } else if (typeof val == 'object') {
+    } else if (typeof val === 'object') {
       return promisify('onDisconnectSetObject', FirestackDatabase)(path, val);
     }
   }
@@ -102,7 +101,7 @@ class DatabaseQuery {
   }
 
   build() {
-    const argsSeparator = ':'
+    const argsSeparator = ':';
     let modifiers = [];
     if (this.orderBy) {
       modifiers.push(this.orderBy.join(argsSeparator));
@@ -114,10 +113,10 @@ class DatabaseQuery {
       .forEach(key => {
         const filter = this.filters[key];
         if (filter) {
-          const filterArgs = [key, filter].join(argsSeparator)
+          const filterArgs = [key, filter].join(argsSeparator);
           modifiers.push(filterArgs);
         }
-      })
+      });
     return modifiers;
   }
 
@@ -180,18 +179,18 @@ class DatabaseRef extends ReferenceBase {
   setAt(val) {
     const path = this.dbPath();
     const value = this._serializeValue(val);
-    return promisify('set', FirestackDatabase)(path, value)
+    return promisify('set', FirestackDatabase)(path, value);
   }
 
   updateAt(val) {
     const path = this.dbPath();
     const value = this._serializeValue(val);
-    return promisify('update', FirestackDatabase)(path, value)
+    return promisify('update', FirestackDatabase)(path, value);
   }
 
   removeAt(key) {
     const path = this.dbPath();
-    return promisify('remove', FirestackDatabase)(path)
+    return promisify('remove', FirestackDatabase)(path);
   }
 
   push(val={}) {
@@ -199,8 +198,8 @@ class DatabaseRef extends ReferenceBase {
     const value = this._serializeValue(val);
     return promisify('push', FirestackDatabase)(path, value)
       .then(({ref}) => {
-        return new DatabaseRef(this.db, ref.split(separator))
-      })
+        return new DatabaseRef(this.db, ref.split(separator));
+      });
   }
 
   on(evt, cb) {
@@ -214,8 +213,8 @@ class DatabaseRef extends ReferenceBase {
                   this.listeners[evt] = subscriptions;
                   callback(this);
                   return subscriptions;
-                })
-    });
+                });
+      });
   }
 
   once(evt='once', cb) {
@@ -229,18 +228,18 @@ class DatabaseRef extends ReferenceBase {
           cb(snapshot);
         }
         return snapshot;
-      })
+      });
   }
 
   off(evt='', origCB) {
     const path = this.dbPath();
     const modifiers = this.dbModifiers();
-    return this.db.off(path, modifiers, evt, origCB)
+    return this.db.off(path, modifiers, evt, origCB);
   }
 
   cleanup() {
     let promises = Object.keys(this.listeners)
-                          .map(key => this.off(key))
+                          .map(key => this.off(key));
     return Promise.all(promises);
   }
 
@@ -254,8 +253,8 @@ class DatabaseRef extends ReferenceBase {
       }
       return {
         ...sum,
-        [key]: val
-      }
+        [key]: val,
+      };
     }, {});
   }
 
@@ -267,8 +266,8 @@ class DatabaseRef extends ReferenceBase {
       }
       return {
         ...sum,
-        [key]: val
-      }
+        [key]: val,
+      };
     }, {});
   }
 
@@ -334,8 +333,8 @@ class DatabaseRef extends ReferenceBase {
   dbPath() {
     let path = this.path;
     let pathStr = (path.length > 0 ? path.join('/') : '/');
-    if (pathStr[0] != '/') {
-      pathStr = `/${pathStr}`
+    if (pathStr[0] !== '/') {
+      pathStr = `/${pathStr}`;
     }
     return pathStr;
   }
@@ -347,7 +346,7 @@ class DatabaseRef extends ReferenceBase {
   }
 
   get namespace() {
-    return `firestack:dbRef`
+    return 'firestack:dbRef';
   }
 }
 
@@ -386,7 +385,7 @@ export class Database extends Base {
       promise = this.whenReady(promisify('enablePersistence', FirestackDatabase)(enable));
       this.persistenceEnabled = enable;
     } else {
-      promise = this.whenReady(Promise.resolve({status: "Already enabled"}))
+      promise = this.whenReady(Promise.resolve({status: 'Already enabled'}))
     }
 
     return promise;
@@ -456,7 +455,7 @@ export class Database extends Base {
     const callback = (ref) => {
       const key = this._pathKey(ref.path);
       this.refs[key] = ref;
-    }
+    };
     const subscriptions = [this.successListener, this.errorListener];
     return Promise.resolve({callback, subscriptions});
   }
@@ -468,7 +467,7 @@ export class Database extends Base {
     // Remove subscription
     if (dbSubscriptions[pathKey]) {
 
-      if (!eventName || eventName === "") {
+      if (!eventName || eventName === '') {
         // remove all listeners for this pathKey
         dbSubscriptions[pathKey] = {};
       }
@@ -545,4 +544,4 @@ export class Database extends Base {
   }
 }
 
-export default Database
+export default Database;

--- a/lib/modules/database.js
+++ b/lib/modules/database.js
@@ -8,6 +8,7 @@ const FirestackDatabaseEvt = new NativeEventEmitter(FirestackDatabase);
 import promisify from '../utils/promisify'
 import { Base, ReferenceBase } from './base'
 
+// subscriptionsMap === { path: { modifier: { eventType: [Subscriptions] } } }
 let dbSubscriptions = {};
 
 class DataSnapshot {
@@ -172,7 +173,8 @@ class DatabaseRef extends ReferenceBase {
   getAt() {
     const path = this.dbPath();
     const modifiers = this.dbModifiers();
-    return promisify('onOnce', FirestackDatabase)(path, modifiers, 'value');
+    const modifiersString = getModifiersString(modifiers);
+    return promisify('onOnce', FirestackDatabase)(path, modifiersString, modifiers, 'value');
   }
 
   setAt(val) {
@@ -204,9 +206,10 @@ class DatabaseRef extends ReferenceBase {
   on(evt, cb) {
     const path = this.dbPath();
     const modifiers = this.dbModifiers();
-    return this.db.on(path, evt, cb)
+    const modifiersString = getModifiersString(modifiers);
+    return this.db.on(path, modifiers, evt, cb)
       .then(({callback, subscriptions}) => {
-        return promisify('on', FirestackDatabase)(path, modifiers, evt)
+        return promisify('on', FirestackDatabase)(path, modifiersString, modifiers, evt)
                 .then(() => {
                   this.listeners[evt] = subscriptions;
                   callback(this);
@@ -218,7 +221,8 @@ class DatabaseRef extends ReferenceBase {
   once(evt='once', cb) {
     const path = this.dbPath();
     const modifiers = this.dbModifiers();
-    return promisify('onOnce', FirestackDatabase)(path, modifiers, evt)
+    const modifiersString = getModifiersString(modifiers);
+    return promisify('onOnce', FirestackDatabase)(path, modifiersString, modifiers, evt)
       .then(({snapshot}) => new DataSnapshot(this, snapshot))
       .then(snapshot => {
         if (cb && typeof cb === 'function') {
@@ -230,23 +234,8 @@ class DatabaseRef extends ReferenceBase {
 
   off(evt='', origCB) {
     const path = this.dbPath();
-    return this.db.off(path, evt, origCB)
-      .then(({callback, subscriptions}) => {
-        if (dbSubscriptions[path] && dbSubscriptions[path][evt].length > 0) {
-          return subscriptions;
-        }
-
-        return promisify('off', FirestackDatabase)(path, evt)
-          .then(() => {
-            // subscriptions.forEach(sub => sub.remove());
-            delete this.listeners[evt];
-            callback(this);
-            return subscriptions;
-          })
-      })
-      .catch(err => {
-        console.error('Never get here', err);
-      })
+    const modifiers = this.dbModifiers();
+    return this.db.off(path, modifiers, evt, origCB)
   }
 
   cleanup() {
@@ -256,7 +245,7 @@ class DatabaseRef extends ReferenceBase {
   }
 
   // Sanitize value
-  // As Firebase cannot store date objects. 
+  // As Firebase cannot store date objects.
   _serializeValue(obj={}) {
     return Object.keys(obj).reduce((sum, key) => {
       let val = obj[key];
@@ -362,6 +351,13 @@ class DatabaseRef extends ReferenceBase {
   }
 }
 
+function getModifiersString(modifiers) {
+  if (!modifiers || !Array.isArray(modifiers)) {
+    return '';
+  }
+  return modifiers.join('|');
+}
+
 export class Database extends Base {
 
   constructor(firestack, options={}) {
@@ -397,21 +393,26 @@ export class Database extends Base {
   }
 
   handleDatabaseEvent(evt) {
-    const body = evt.body;
+    const body = evt.body || {};
     const path = body.path;
-    const evtName = body.eventName;
+    const modifiersString = body.modifiersString || '';
+    const modifier = modifiersString;
+    const eventName = body.eventName;
 
-    const subscriptions = dbSubscriptions[path];
-
-    if (subscriptions) {
-      const cbs = subscriptions[evtName];
-      cbs.forEach(cb => {
-        if (cb && typeof(cb) === 'function') {
-          const snap = new DataSnapshot(this, body.snapshot);
-          this.log.debug('database_event received', path, evtName);
-          cb(snap, body);
-        }
-      });
+    // subscriptionsMap === { path: { modifier: { eventType: [Subscriptions] } } }
+    const modifierMap = dbSubscriptions[path];
+    if (modifierMap) {
+      const eventTypeMap = modifierMap[modifier];
+      if (eventTypeMap) {
+        const callbacks = eventTypeMap[eventName] || [];
+        callbacks.forEach(cb => {
+          if (cb && typeof(cb) === 'function') {
+            const snap = new DataSnapshot(this, body.snapshot);
+            this.log.debug('database_event received', path, eventName);
+            cb(snap, body);
+          }
+        });
+      }
     }
   }
 
@@ -419,29 +420,36 @@ export class Database extends Base {
     this.log.debug('handleDatabaseError ->', evt);
   }
 
-  on(path, evt, cb) {
+  on(path, modifiers, evt, cb) {
     const key = this._pathKey(path);
+    const modifiersString = getModifiersString(modifiers);
+    const modifier = modifiersString;
 
     if (!dbSubscriptions[key]) {
       dbSubscriptions[key] = {};
     }
 
-    if (!dbSubscriptions[key][evt]) {
-      dbSubscriptions[key][evt] = [];
+    if (!dbSubscriptions[key][modifier]) {
+      dbSubscriptions[key][modifier] = {};
     }
-    dbSubscriptions[key][evt].push(cb);
+
+    if (!dbSubscriptions[key][modifier][evt]) {
+      dbSubscriptions[key][modifier][evt] = [];
+    }
+
+    dbSubscriptions[key][modifier][evt].push(cb);
 
     if (!this.successListener) {
       this.successListener = FirestackDatabaseEvt
         .addListener(
-          'database_event', 
+          'database_event',
           this.handleDatabaseEvent.bind(this));
     }
 
     if (!this.errorListener) {
       this.errorListener = FirestackDatabaseEvt
         .addListener(
-          'database_error', 
+          'database_error',
           this.handleDatabaseError.bind(this));
     }
 
@@ -453,48 +461,71 @@ export class Database extends Base {
     return Promise.resolve({callback, subscriptions});
   }
 
-  off(path, evt, origCB) {
-    const key = this._pathKey(path);
+  off(path, modifiers, eventName, origCB) {
+    const pathKey = this._pathKey(path);
+    const modifiersString = getModifiersString(modifiers);
+    const modifier = modifiersString;
     // Remove subscription
-    if (dbSubscriptions[key]) {
-      if (!evt || evt === "") {
-        dbSubscriptions[key] = {};
-      } else if (dbSubscriptions[key][evt]) {
-        if (origCB) {
-          dbSubscriptions[key][evt].splice(dbSubscriptions[key][evt].indexOf(origCB), 1);
-        } else {
-          delete dbSubscriptions[key][evt];
+    if (dbSubscriptions[pathKey]) {
+
+      if (!eventName || eventName === "") {
+        // remove all listeners for this pathKey
+        dbSubscriptions[pathKey] = {};
+      }
+
+      if (dbSubscriptions[pathKey][modifier]) {
+        if (dbSubscriptions[pathKey][modifier][eventName]) {
+          if (origCB) {
+            // remove only the given callback
+            dbSubscriptions[pathKey][modifier][eventName].splice(dbSubscriptions[pathKey][modifier][eventName].indexOf(origCB), 1);
+          }
+          else {
+            // remove all callbacks for this path:modifier:eventType
+            delete dbSubscriptions[pathKey][modifier][eventName];
+          }
         }
       }
 
-      if (Object.keys(dbSubscriptions[key]).length <= 0) {
-        // there are no more subscriptions
-        // so we can unwatch
-        delete dbSubscriptions[key]
+      if (Object.keys(dbSubscriptions[pathKey]).length <= 0) {
+        // there are no more subscriptions so we can unwatch
+        delete dbSubscriptions[pathKey];
       }
-      if (Object.keys(dbSubscriptions).length == 0) {
+      if (Object.keys(dbSubscriptions).length === 0) {
         if (this.successListener) {
           this.successListener.remove();
           this.successListener = null;
         }
         if (this.errorListener) {
           this.errorListener.remove();
-          this.errorListener = null; 
+          this.errorListener = null;
         }
       }
     }
+
     const callback = (ref) => {
       const key = this._pathKey(ref.path);
       delete this.refs[key];
-    }
+    };
+
     const subscriptions = [this.successListener, this.errorListener];
-    return Promise.resolve({callback, subscriptions});
+
+    let modifierMap = dbSubscriptions[path];
+    if (modifierMap && modifierMap[modifier] && modifierMap[modifier][eventName] && modifierMap[modifier][eventName].length > 0) {
+      return Promise.resolve(subscriptions);
+    }
+
+    return promisify('off', FirestackDatabase)(path, modifiersString, eventName).then(() => {
+      // subscriptions.forEach(sub => sub.remove());
+      // delete this.listeners[eventName];
+      callback(this);
+      return subscriptions;
+    });
   }
 
   cleanup() {
     let promises = Object.keys(this.refs)
                           .map(key => this.refs[key])
-                          .map(ref => ref.cleanup())
+                          .map(ref => ref.cleanup());
     return Promise.all(promises);
   }
 
@@ -510,7 +541,7 @@ export class Database extends Base {
   }
 
   get namespace() {
-    return 'firestack:database'
+    return 'firestack:database';
   }
 }
 


### PR DESCRIPTION
Fix listeners with modifiers reusing handles with the same path but no modifiers

We now keep track of the listeners by path as well as modifierString, and to a lesser extent, by eventType

Previously, if we have:
 a) `db.ref('/messages').on('child_added')`
 b) `db.ref('/messages').limitToFirst(1).on('child_added')`
 c) `db.ref('/messages').limitToLast(1).on('child_added')`

In short:
If we were to push a new message onto /messages, the 'b' query above with limitToFirst would fire its child_added listenerwould get called, despite only the last element having changed

Longer explanation:
it will reuse the same javascript subscription, and it will create 3 unique path+modifier references in the native code, to which we'll attach:
ios: only the appropriate listener
android: the multi-listener for all eventTypes

these listeners will fire correctly whenever (compare with a, b & c above):
a) anything gets added
b) when the last item changes
c) when the first item changes
but when any of these three listeners emit an event, *all* 3 will receive it