### PR TITLE
Fix Android listenForAuth method to correctly check for user

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
@@ -68,7 +68,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
         WritableMap msgMap = Arguments.createMap();
         msgMap.putString("eventName", "listenForAuth");
 
-        if (FirestackAuthModule.this.user != null) {
+        if (firebaseAuth.getCurrentUser() != null) {
             WritableMap userMap = getUserMap();
 
             msgMap.putBoolean("authenticated", true);


### PR DESCRIPTION
listenForAuth was not correctly checking for a user object so the user object was never populated on the callback.