### PR TITLE
Removing undefined's from filter arguments

### DIFF
--- a/lib/modules/database.js
+++ b/lib/modules/database.js
@@ -96,7 +96,7 @@ class DatabaseQuery {
   }
 
   setFilter(name, ...args) {
-    this.filters[name] = args;
+    this.filters[name] = args.filter(n => n != undefined);
     return this.ref;
   }
 


### PR DESCRIPTION
* Removes trailing comma. java String#split has a different behaviour from componentsseparatedbystring, which leads to a bug.
* Problem resides in `equalTo` passing undefined to `setFilter` when no key is present.
* _Not_ tested besides `equalTo` filter in android! Can break other filters. Requires further testing.