### PR TITLE
Use storage url from .plist file if not setStorageUrl() hasn't been called

### DIFF
--- a/ios/Firestack/FirestackStorage.m
+++ b/ios/Firestack/FirestackStorage.m
@@ -25,7 +25,12 @@ RCT_EXPORT_METHOD(downloadUrl: (NSString *) storageUrl
                   path:(NSString *) path
     callback:(RCTResponseSenderBlock) callback)
 {
-    FIRStorageReference *storageRef = [[FIRStorage storage] referenceForURL:storageUrl];
+    FIRStorageReference *storageRef;
+    if (storageUrl == nil ) {
+        storageRef = [[FIRStorage storage] reference];
+    } else {
+        storageRef = [[FIRStorage storage] referenceForURL:storageUrl];
+    }
     FIRStorageReference *fileRef = [storageRef child:path];
     [fileRef downloadURLWithCompletion:^(NSURL * _Nullable URL, NSError * _Nullable error) {
         if (error != nil) {

--- a/ios/Firestack/FirestackStorage.m
+++ b/ios/Firestack/FirestackStorage.m
@@ -52,14 +52,13 @@ RCT_EXPORT_METHOD(uploadFile: (NSString *) urlStr
                   metadata:(NSDictionary *)metadata
                   callback:(RCTResponseSenderBlock) callback)
 {
+    FIRStorageReference *storageRef;
     if (urlStr == nil) {
-        NSError *err = [[NSError alloc] init];
-        [err setValue:@"Storage configuration error" forKey:@"name"];
-        [err setValue:@"Call setStorageUrl() first" forKey:@"description"];
-        return callback(@[err]);
+        storageRef = [[FIRStorage storage] reference];
+    } else {
+        storageRef = [[FIRStorage storage] referenceForURL:urlStr];
     }
 
-    FIRStorageReference *storageRef = [[FIRStorage storage] referenceForURL:urlStr];
     FIRStorageReference *uploadRef = [storageRef child:name];
     FIRStorageMetadata *firmetadata = [[FIRStorageMetadata alloc] initWithDictionary:metadata];
 


### PR DESCRIPTION
- Fix weird error that NSError is not KVC compliant when storage is not configured in
JS
- Fixed code seems to exist on several more locations but has not been fixed,
since there are no tests to ensure I don't break anything.