### PR TITLE
Fix .equalTo, .endAt, and .startAt filters when used without key.

### DIFF
--- a/lib/modules/database.js
+++ b/lib/modules/database.js
@@ -294,14 +294,23 @@ class DatabaseRef extends ReferenceBase {
 
   // Filters
   equalTo(value, key) {
+    if (!key) {
+      return this.query.setFilter('equalTo', value);
+    }
     return this.query.setFilter('equalTo', value, key);
   }
 
   endAt(value, key) {
+    if (!key) {
+      return this.query.setFilter('endAt', value);
+    }
     return this.query.setFilter('endAt', value, key);
   }
 
   startAt(value, key) {
+    if (!key) {
+      return this.query.setFilter('startAt', value);
+    }
     return this.query.setFilter('startAt', value, key);
   }
 

--- a/lib/modules/storage.js
+++ b/lib/modules/storage.js
@@ -101,8 +101,8 @@ export class Storage extends Base {
     return FirestackStorageEvt.addListener(evt, cb);
   }
 
-  _removeListener(evt) {
-    return FirestackStorageEvt.removeListener(evt);
+  _removeListener(subscription) {
+    return FirestackStorageEvt.removeListener(subscription.eventType, subscription.listener);
   }
 
   setStorageUrl(url) {


### PR DESCRIPTION
- When used without key they contained a spurious comma, since
['equalTo', ['a', undefined]].join(':') is 'equalTo:a,' (with comma at the end) and not  'equalTo:a' which would be the result of ['equalTo', ['a']].join(':').