### PR TITLE
Fix possible Null Pointer Exception when logging an event on Android

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackUtils.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackUtils.java
@@ -164,8 +164,12 @@ public class FirestackUtils {
   }
 
   public static Map<String, Object> recursivelyDeconstructReadableMap(ReadableMap readableMap) {
-      ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
       Map<String, Object> deconstructedMap = new HashMap<>();
+      if (readableMap == null) {
+        return deconstructedMap;
+      }
+
+      ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
       while (iterator.hasNextKey()) {
           String key = iterator.nextKey();
           ReadableType type = readableMap.getType(key);


### PR DESCRIPTION
At the moment a NullPointerException is thrown when logging an event to Firebase Analytics that has no parameters.