### PR TITLE
Add `invariant` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "bows": "^1.6.0",
-    "es6-symbol": "^3.1.0"
+    "es6-symbol": "^3.1.0",
+    "invariant": "^2.2.2"
   }
 }


### PR DESCRIPTION
Add `invariant` dependency to avoid error during usage.
