### PR TITLE
Readme link to firebase.google.com not firebase.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Firestack
 
-Firestack makes using the latest [Firebase](http://firebase.com) straight-forward.
+Firestack makes using the latest [Firebase](https://firebase.google.com/) straight-forward.
 
 [![Gitter](https://badges.gitter.im/fullstackreact/react-native-firestack.svg)](https://gitter.im/fullstackreact/react-native-firestack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
[Firebase.com](https://firebase.com) is the legacy console. [Firebase.google.com](https://firebase.google.com/) is the latest firebase console.