### PR TITLE
Fix example FBLogin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ var Login = React.createClass({
           console.log("Logged in!");
           console.log(data);
           let token = data.credentials.token
-          firestack.signInWithProvider('facebook', token, '') // facebook need only access token.
+          firestack.auth.signInWithProvider('facebook', token, '') // facebook need only access token.
             .then((user)=>{
               console.log(user)
             })


### PR DESCRIPTION
The `.auth` was missing in the example for the Facebook Login. 
It throws an error if you copy/paste the example and run it `firestack.signInWithProvider is not a function`.