### PR TITLE
update manual install doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 ].each do |lib|
   pod lib
 end
+
+target '[project name]' do
+end
+
+# target '[project test name]' do
+# end
 ```
 
 Then you can run `(cd ios && pod install)` to get the pods opened. If you do use this route, remember to use the `.xcworkspace` file.


### PR DESCRIPTION
When you install `react-native-firestack` manually without using `react-native link`, you have to add 
```ruby
target '[project name]' do
end
```
to your Podfile that you created. Other wise you will get following error.

```sh
[!] The dependency `Firebase/Core` is not used in any concrete target.
The dependency `Firebase/Auth` is not used in any concrete target.
The dependency `Firebase/Storage` is not used in any concrete target.
The dependency `Firebase/Database` is not used in any concrete target.
The dependency `Firebase/RemoteConfig` is not used in any concrete target.
The dependency `Firebase/Messaging` is not used in any concrete target.
```

OS: MacOS Sierra
react-native: v0.40.0
Target: iOS 8.0