### PR TITLE
Consistency with values emitted by firebase.auth.AuthProvider subclasses

### DIFF
--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -67,14 +67,10 @@ RCT_EXPORT_METHOD(signInWithCustomToken:
 }
 
 RCT_EXPORT_METHOD(signInWithProvider:
-                  (NSString *)provider
-                  token:(NSString *)authToken
-                  secret:(NSString *)authTokenSecret
+                  (NSDictionary *)credentialData
                   callback:(RCTResponseSenderBlock)callback)
 {
-    FIRAuthCredential *credential = [self getCredentialForProvider:provider
-                                                             token:authToken
-                                                            secret:authTokenSecret];
+    FIRAuthCredential *credential = [self getCredentialForProvider:credentialData];
     if (credential == nil) {
         NSDictionary *err = @{
                               @"error": @"Unhandled provider"
@@ -340,14 +336,10 @@ RCT_EXPORT_METHOD(getTokenWithCompletion:(RCTResponseSenderBlock) callback)
 }
 
 RCT_EXPORT_METHOD(reauthenticateWithCredentialForProvider:
-                  (NSString *)provider
-                  token:(NSString *)authToken
-                  secret:(NSString *)authTokenSecret
+                  (NSDictionary *)credentialData
                   callback:(RCTResponseSenderBlock)callback)
 {
-    FIRAuthCredential *credential = [self getCredentialForProvider:provider
-                                                             token:authToken
-                                                            secret:authTokenSecret];
+    FIRAuthCredential *credential = [self getCredentialForProvider:credentialData];
     if (credential == nil) {
         NSDictionary *err = @{
                               @"error": @"Unhandled provider"
@@ -440,19 +432,23 @@ RCT_EXPORT_METHOD(updateUserProfile:(NSDictionary *)userProps
     }];
 }
 
-- (FIRAuthCredential *)getCredentialForProvider:(NSString *)provider
-                                          token:(NSString *)authToken
-                                         secret:(NSString *)authTokenSecret
+- (FIRAuthCredential *)getCredentialForProvider:(NSDictionary *)credentialData
 {
     FIRAuthCredential *credential;
-    if ([provider compare:@"twitter" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-        credential = [FIRTwitterAuthProvider credentialWithToken:authToken
-                                                          secret:authTokenSecret];
-    } else if ([provider compare:@"facebook" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-        credential = [FIRFacebookAuthProvider credentialWithAccessToken:authToken];
-    } else if ([provider compare:@"google" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-        credential = [FIRGoogleAuthProvider credentialWithIDToken:authToken
-                                                      accessToken:authTokenSecret];
+    NSString *provider = [credentialData valueForKey:@"provider"];
+    if ([provider compare:@"twitter.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        NSString *accessToken = [credentialData valueForKey:@"accessToken"];
+        NSString *secret = [credentialData valueForKey:@"secret"];
+        credential = [FIRTwitterAuthProvider credentialWithToken:accessToken
+                                                          secret:secret];
+    } else if ([provider compare:@"facebook.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        NSString *accessToken = [credentialData valueForKey:@"accessToken"];
+        credential = [FIRFacebookAuthProvider credentialWithAccessToken:accessToken];
+    } else if ([provider compare:@"google.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        NSString *idToken = [credentialData valueForKey:@"idToken"];
+        NSString *accessToken = [credentialData valueForKey:@"accessToken"];
+        credential = [FIRGoogleAuthProvider credentialWithIDToken:idToken
+                                                      accessToken:accessToken];
     } else {
         NSLog(@"Provider not yet handled: %@", provider);
     }

--- a/lib/modules/auth.js
+++ b/lib/modules/auth.js
@@ -138,16 +138,16 @@ export default class Auth extends Base {
    * Sign the user in with a third-party authentication provider
    * @return {Promise}           A promise resolved upon completion
    */
-  signInWithCredential(credential: CredentialType): Promise<Object> {
-    return promisify('signInWithProvider', FirestackAuth)(credential.provider, credential.token, credential.secret);
+  signInWithCredential(credential: any): Promise<Object> {
+    return promisify('signInWithProvider', FirestackAuth)(credential);
   }
 
   /**
    * Re-authenticate a user with a third-party authentication provider
    * @return {Promise}         A promise resolved upon completion
    */
-  reauthenticateUser(credential: CredentialType): Promise<Object> {
-    return promisify('reauthenticateWithCredentialForProvider', FirestackAuth)(credential.provider, credential.token, credential.secret);
+  reauthenticateUser(credential: any): Promise<Object> {
+    return promisify('reauthenticateWithCredentialForProvider', FirestackAuth)(credential);
   }
 
   /**


### PR DESCRIPTION
The objects emitted by the `credential` method of `firebase.auth.TwitterAuthProvider`, `firebase.auth.FacebookAuthProvider`, and `firebase.auth.GoogleAuthProvider` all have different shapes. 

This lets me do
```js
var firebasejs = require('firebase');
var credential = firebasejs.auth.FacebookAuthProvider.credential(accessToken);
var auth = firestack.auth().signInWithCredential(credential);
```
