### PR TITLE
Remove serverTimeOffset references in constructor

### DIFF
--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -33,10 +33,16 @@ export default class Database extends Base {
       err => this._handleDatabaseError(err)
     );
 
+    /**
+     * Creating references in the constructor will break 'setPersistence'
+     */
+
+    /*
     this.offsetRef = this.ref('.info/serverTimeOffset');
     this.offsetRef.on('value', (snapshot) => {
       this.serverTimeOffset = snapshot.val() || this.serverTimeOffset;
     });
+    */
 
     this.log.debug('Created new Database instance', this.options);
   }

--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -19,7 +19,6 @@ export default class Database extends Base {
   constructor(firestack: Object, options: Object = {}) {
     super(firestack, options);
     this.subscriptions = {};
-    this.serverTimeOffset = 0;
     this.persistenceEnabled = false;
     this.namespace = 'firestack:database';
 
@@ -32,17 +31,6 @@ export default class Database extends Base {
       'database_error',
       err => this._handleDatabaseError(err)
     );
-
-    /**
-     * Creating references in the constructor will break 'setPersistence'
-     */
-
-    /*
-    this.offsetRef = this.ref('.info/serverTimeOffset');
-    this.offsetRef.on('value', (snapshot) => {
-      this.serverTimeOffset = snapshot.val() || this.serverTimeOffset;
-    });
-    */
 
     this.log.debug('Created new Database instance', this.options);
   }
@@ -162,9 +150,6 @@ export default class Database extends Base {
   /**
    *  INTERNALS
    */
-  _getServerTime() {
-    return new Date().getTime() + this.serverTimeOffset;
-  }
 
   /**
    *
@@ -176,7 +161,6 @@ export default class Database extends Base {
   _handle(path: string = '', modifiersString: string = '') {
     return `${path}|${modifiersString}`;
   }
-
 
   /**
    *


### PR DESCRIPTION
Creating references in the database constructor will break 'setPersistence', which can only be called before any references have been created.