### PR TITLE
Made setPersistence internal and added option 'persistence'

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -66,6 +66,7 @@ We can pass _custom_ options by passing an object with configuration options. Th
 | option           | type | Default Value           | Description                                                                                                                                                                                                                                                                                                                                                      |
 |----------------|----------|-------------------------|----------------------------------------|
 | debug | bool | false | When set to true, Firestack will log messages to the console and fire `debug` events we can listen to in `js` |
+| persistence | bool | false | When set to true, database will persist data locally |
 | bundleID | string | Default from app `[NSBundle mainBundle]` | The bundle ID for the app to be bundled with |
 | googleAppID | string | "" | The Google App ID that is used to uniquely identify an instance of an app. |
 | databaseURL | string | "" | The database root (i.e. https://my-app.firebaseio.com) |
@@ -76,7 +77,6 @@ We can pass _custom_ options by passing an object with configuration options. Th
 | trackingID | string | "" | The tracking ID for Google Analytics |
 | clientID | string | "" | The OAuth2 client ID for iOS application used to authenticate Google Users for signing in with Google |
 | APIKey | string | "" | The secret iOS API key used for authenticating requests from our app |
-| persistence | bool | false | Enable database persistence |
 
 For instance:
 

--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -76,6 +76,7 @@ We can pass _custom_ options by passing an object with configuration options. Th
 | trackingID | string | "" | The tracking ID for Google Analytics |
 | clientID | string | "" | The OAuth2 client ID for iOS application used to authenticate Google Users for signing in with Google |
 | APIKey | string | "" | The secret iOS API key used for authenticating requests from our app |
+| persistence | bool | false | Enable database persistence |
 
 For instance:
 

--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -314,7 +314,7 @@ RCT_EXPORT_METHOD(getToken:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenError"];
             } else {
-                [self userCallback:callback user:user];
+                callback(@[[NSNull null], token]);
             }
         }];
     } else {
@@ -331,7 +331,7 @@ RCT_EXPORT_METHOD(getTokenWithCompletion:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenWithCompletion"];
             } else {
-                [self userCallback:callback user:user];
+                callback(@[[NSNull null], token]);
             }
         }];
     } else {

--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -314,7 +314,7 @@ RCT_EXPORT_METHOD(getToken:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenError"];
             } else {
-                callback(@[[NSNull null], token]);
+                [self userCallback:callback user:user];
             }
         }];
     } else {
@@ -331,7 +331,7 @@ RCT_EXPORT_METHOD(getTokenWithCompletion:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenWithCompletion"];
             } else {
-                callback(@[[NSNull null], token]);
+                [self userCallback:callback user:user];
             }
         }];
     } else {

--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -33,6 +33,10 @@ export default class Database extends Base {
       err => this._handleDatabaseError(err)
     );
 
+    if (options.persistence === true) {
+      this._setPersistence(true);
+    }
+
     this.offsetRef = this.ref('.info/serverTimeOffset');
     this.offsetRef.on('value', (snapshot) => {
       this.serverTimeOffset = snapshot.val() || this.serverTimeOffset;
@@ -54,21 +58,6 @@ export default class Database extends Base {
    */
   ref(...path: Array<string>) {
     return new Reference(this, path);
-  }
-
-  /**
-   * Enabled / disable database persistence
-   * @param enable
-   * @returns {*}
-   */
-  setPersistence(enable: boolean = true) {
-    if (this.persistenceEnabled !== enable) {
-      this.log.debug(`${enable ? 'Enabling' : 'Disabling'} persistence`);
-      this.persistenceEnabled = enable;
-      return this.whenReady(promisify('enablePersistence', FirestackDatabase)(enable));
-    }
-
-    return this.whenReady(Promise.resolve({ status: 'Already enabled' }));
   }
 
   /**
@@ -158,6 +147,21 @@ export default class Database extends Base {
    */
   _getServerTime() {
     return new Date().getTime() + this.serverTimeOffset;
+  }
+
+  /**
+   * Enabled / disable database persistence
+   * @param enable
+   * @returns {*}
+   */
+  _setPersistence(enable: boolean = true) {
+    if (this.persistenceEnabled !== enable) {
+      this.log.debug(`${enable ? 'Enabling' : 'Disabling'} persistence`);
+      this.persistenceEnabled = enable;
+      return this.whenReady(promisify('enablePersistence', FirestackDatabase)(enable));
+    }
+
+    return this.whenReady(Promise.resolve({ status: 'Already enabled' }));
   }
 
   /**

--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -32,7 +32,7 @@ export default class Database extends Base {
       'database_error',
       err => this._handleDatabaseError(err)
     );
-
+console.log(options);
     if (options.persistence === true) {
       this._setPersistence(true);
     }

--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -32,8 +32,8 @@ export default class Database extends Base {
       'database_error',
       err => this._handleDatabaseError(err)
     );
-console.log(options);
-    if (options.persistence === true) {
+
+    if (firestack.options.persistence === true) {
       this._setPersistence(true);
     }
 


### PR DESCRIPTION
`setPersistence` has to be called before any database references have been created. Since the database constructor immediately creates refs to `.info/serverTimeOffset`, calling `setPersistence` will always throw and it is not possible to enable persistence currently. Furthermore, `setPersistence` is not part of the Web SDK API anyway.

To fix this issue https://github.com/fullstackreact/react-native-firestack/issues/216, this PR makes `setPersistence` internal and adds instead an option `persistence` that can be supplied to the Firestack constructor. This guarantees that persistence will be enabled before any refs are created. The default value is `false`.

```
const firestack = new Firestack({ persistence: true });
```