### PR TITLE
[v3] Fix getToken to return JWT token instead of user

### DIFF
--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -314,7 +314,7 @@ RCT_EXPORT_METHOD(getToken:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenError"];
             } else {
-                [self userCallback:callback user:user];
+                callback(@[[NSNull null], token]);
             }
         }];
     } else {
@@ -331,7 +331,7 @@ RCT_EXPORT_METHOD(getTokenWithCompletion:(RCTResponseSenderBlock) callback)
             if (error) {
                 [self userErrorCallback:callback error:error user:user msg:@"getTokenWithCompletion"];
             } else {
-                [self userCallback:callback user:user];
+                callback(@[[NSNull null], token]);
             }
         }];
     } else {


### PR DESCRIPTION
`getToken` should return the JWT token and not the user object. This fixes https://github.com/fullstackreact/react-native-firestack/issues/230