### PR TITLE
Fix example provider name

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -100,7 +100,7 @@ Sign in the user with a 3rd party credential provider. `credential` requires the
 
 ```javascript
 const credential = {
-  provider: 'facebook.com', 
+  provider: 'facebook', 
   token: '12345', 
   secret: '6789', 
 };


### PR DESCRIPTION
using 'facebook.com' throws an error