### PR TITLE
Guarantee a Promise from requestPermissions

### DIFF
--- a/lib/modules/cloudmessaging.js
+++ b/lib/modules/cloudmessaging.js
@@ -31,10 +31,8 @@ export class CloudMessaging extends Base {
                 this.requestedPermissions, 
                 requestedPermissions);
             return promisify('requestPermissions', FirestackCloudMessaging)(mergedRequestedPermissions)
-                .then(perms => {
-                    
-                    return perms;
-                });
+        } else {
+            return Promise.resolve();
         }
     }
 


### PR DESCRIPTION
requestPermissions silently returns for Android. By guaranteeing a promise, the function can be used without the dependent code having to check for platform.