### PR TITLE
Make firestackModule.js working for v3

### DIFF
--- a/lib/firestackModule.js
+++ b/lib/firestackModule.js
@@ -56,7 +56,7 @@ export class FirestackModule {
 
   makeRef(path) {
     const refName = [this._refName, path]
-    const ref = this._firestack.database.ref(...refName);
+    const ref = this._firestack.database().ref(...refName);
     return this._makeRef(ref);
   }
 


### PR DESCRIPTION
`this._firestack.database.ref(...refName)` (line 39) should be `this._firestack.database().ref(...refName)`