### PR TITLE
Corrections in docs

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -100,9 +100,9 @@ Sign in the user with a 3rd party credential provider. `credential` requires the
 
 ```javascript
 const credential = {
-  provider: 'facebook', 
-  token: '12345', 
-  secret: '6789', 
+  provider: 'facebook.com', 
+  accessToken: '12345', 
+  //secret: '6789', //'secret' does not apply to facebook authentication
 };
 
 firestack.auth().signInWithCredential(credential)


### PR DESCRIPTION
A couple mistakes in the docs that I tracked down in terms of keys and values for credentials. I have facebook auth working in my app now as a result of these changes (I've verified)