### PR TITLE
don't hardcode firebase dependencies versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,12 +45,12 @@ allprojects {
 dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
     compile 'com.google.android.gms:play-services-base:+'
-    compile 'com.google.firebase:firebase-core:10.0.1'
-    compile 'com.google.firebase:firebase-config:10.0.1'
-    compile 'com.google.firebase:firebase-auth:10.0.1'
-    compile 'com.google.firebase:firebase-analytics:10.0.1'
-    compile 'com.google.firebase:firebase-database:10.0.1'
-    compile 'com.google.firebase:firebase-storage:10.0.1'
-    compile 'com.google.firebase:firebase-messaging:10.0.1'
+    compile 'com.google.firebase:firebase-core:+'
+    compile 'com.google.firebase:firebase-config:+'
+    compile 'com.google.firebase:firebase-auth:+'
+    compile 'com.google.firebase:firebase-analytics:+'
+    compile 'com.google.firebase:firebase-database:+'
+    compile 'com.google.firebase:firebase-storage:+'
+    compile 'com.google.firebase:firebase-messaging:+'
 }
 


### PR DESCRIPTION
If the `play-services-base` dependency version requirement is "soft", then so should the firebase dependencies as they all need to be on the same version so as not to get the [Multiple dex files error](https://github.com/fullstackreact/react-native-firestack/issues/134).