### PR TITLE
[fix #321] Fixes the crash when the user opens the app while offline

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
@@ -598,7 +598,16 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
         Log.e(TAG, ex.getMessage());
       }
 
-      onFail.invoke(error);
+      try {
+          onFail.invoke(error);
+      } catch (RuntimeException ex) {
+          // Firebase tries to login 3 times, so the callback might
+          // be called as much as that. This will prevent a crash in case
+          // the callback throws the following error:
+          // java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
+          Log.e(TAG, ex.getMessage());
+      }
+
     }
 
     private WritableMap getUserMap() {


### PR DESCRIPTION
This bug happens because firebase tries to login 3 times if the user is offline. Because of this the callback will be called several times (2 times more than it should). 

This will catch the exception from it so that the callback doesn't crash if this happens (just show the error)