### PR TITLE
Adds a "list" method to FirestackModule

### DIFF
--- a/lib/firestackModule.js
+++ b/lib/firestackModule.js
@@ -9,6 +9,7 @@ const createTypes = (prefix) => {
 
     ACTION_LISTEN: c('listen'),
     ACTION_UNLISTEN: c('unlisten'),
+    ACTION_LIST: c('list'),
     ACTION_REMOVE: c('remove'),
     ACTION_UPDATE: c('update'),
     ACTION_SET: c('set'),
@@ -17,6 +18,7 @@ const createTypes = (prefix) => {
     ITEM_ADDED: c('added'),
     ITEM_REMOVED: c('remove'),
     ITEM_CHANGED: c('changed'),
+    LIST_UPDATED: c('updated'),
     UPDATED: c('updated')
   }
 }
@@ -137,6 +139,32 @@ export class FirestackModule {
     })
   }
 
+  list(cb) {
+    let store = this._getStore();
+    invariant(store, 'Please set the store');
+
+    const T = this._types;
+    const listenRef = this.makeRef();
+    const toObject = this._toObject;
+
+    return new Promise((resolve, reject) => {
+        listenRef.once('value', (snapshot) => {
+            const state = this._getState(); // local state
+            let list = [];
+
+            snapshot.forEach(function(childSnapshot) {
+                list.push({_key: childSnapshot.key || childSnapshot.value.key, ...childSnapshot.value})
+            });
+            list = list.sort(this._sortFn)
+            return this._handleUpdate(T.LIST_UPDATED, {items: list}, cb);
+        });
+
+        this._handleUpdate(T.ACTION_LIST, null, (state) => {
+            resolve(state)
+        })
+    })
+  }
+
   // TODO: Untested
   getAt(path, cb) {
     const T = this._types;
@@ -217,7 +245,7 @@ export class FirestackModule {
     }
 
     return [
-      'listen', 'unlisten',
+      'listen', 'unlisten', 'list',
       'getAt', 'setAt', 'updateAt', 'removeAt'
     ].reduce((sum, name) => {
       return {


### PR DESCRIPTION
I needed a method to create a simple `list` of the items on the database. By any reason `listen` + `unlisten` was giving me the wrong results, repeating some items and etc. 
The code, as is, is in use in my current app.

