### PR TITLE
configureWithOptions fix for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
-    compile 'com.google.android.gms:play-services-base:+'
+    compile 'com.google.android.gms:play-services-base:10.0.1'
 
     compile 'com.google.firebase:firebase-core:10.0.1'
     compile 'com.google.firebase:firebase-auth:10.0.1'
@@ -29,4 +29,3 @@ dependencies {
     compile 'com.google.firebase:firebase-storage:10.0.1'
     compile 'com.google.firebase:firebase-messaging:10.0.1'
 }
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,12 +20,12 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
-    compile 'com.google.android.gms:play-services-base:10.0.1'
+    compile 'com.google.android.gms:play-services-base:10.2.1'
 
-    compile 'com.google.firebase:firebase-core:10.0.1'
-    compile 'com.google.firebase:firebase-auth:10.0.1'
-    compile 'com.google.firebase:firebase-analytics:10.0.1'
-    compile 'com.google.firebase:firebase-database:10.0.1'
-    compile 'com.google.firebase:firebase-storage:10.0.1'
-    compile 'com.google.firebase:firebase-messaging:10.0.1'
+    compile 'com.google.firebase:firebase-core:10.2.1'
+    compile 'com.google.firebase:firebase-auth:10.2.1'
+    compile 'com.google.firebase:firebase-analytics:10.2.1'
+    compile 'com.google.firebase:firebase-database:10.2.1'
+    compile 'com.google.firebase:firebase-storage:10.2.1'
+    compile 'com.google.firebase:firebase-messaging:10.2.1'
 }


### PR DESCRIPTION
When a google-services.json is provided, Firestack auto-configures itself (see [this article](https://firebase.googleblog.com/2016/12/how-does-firebase-initialize-on-android.html)), so there is no way to pass custom options afterwards. 

Removing the google-services.json didn't solve the issue, since building a `FirebaseOptions` without an applicationId throws an exception. 

This patch detects if the firebase default app is already configured, otherwise uses params to set it up, without trying to build an empty `FirebaseOptions`.
Il also refactored a little bit the way params keys are searched to be complient with the params in the ios version. 
I think this patch might resolve most of the "FirebaseApp[DEFAULT] already configured" errors in android apps, like in #265

Maybe the README should be updated to state clearly that .plist/.json and options from js are mutually exclusives way to configure firestack. 
 