### PR TITLE
Fix crash that happens when Firebase API key gets revoked

### DIFF
--- a/ios/Firestack/FirestackAuth.m
+++ b/ios/Firestack/FirestackAuth.m
@@ -159,7 +159,7 @@ RCT_EXPORT_METHOD(listenForAuth)
                                              props: @{
                                                       @"eventName": @"userTokenError",
                                                       @"authenticated": @((BOOL)false),
-                                                      @"errorMessage": [error localizedFailureReason]
+                                                      @"errorMessage": @"An error occured, please try again"
                                                       }];
                                         } else {
                                             [self


### PR DESCRIPTION
Fixes https://github.com/fullstackreact/react-native-firestack/issues/318

This has been really hard to reproduce and track down: When an API key gets revoked the stored auth token is not valid any more, causing this error. `error localizedFailureReason` doesn't contain anything in that case, so it's `nil`, causing Objective-C to crash as you can't have it as a value for a dictionary. 

It's probably save to have the default text here, but feel free to tweak it and modify the PR directly as necessary.

Let me know if you have any other questions. I'm using `firestack` for my side project [wwdc.family](https://wwdc.family) :+1: