### PR TITLE
update readme to show no longer maintain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+----
+### This library is no longer maintained, use at your own risk or please [seek alternatives on npm](https://www.npmjs.com/search?q=react+native+firebase).
+----
+
 ## Firestack
 
 Firestack makes using the latest [Firebase](https://firebase.google.com/) straight-forward.


### PR DESCRIPTION
Hi, I found many issue when I tried using this today for my app but I see reading from comment in issues that this no longer maintain? I think to avoid the time wasting for other people the readme should say that it no longer maintain and seek other libraries. 

I not sure which other libraries to suggest so I add link to npm search for `react native firebase` - there some other library there, maybe someone suggest?

Thanks you